### PR TITLE
Feat/#26/clothes attri delete

### DIFF
--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/controller/ClothesAttributeDefinitionController.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/controller/ClothesAttributeDefinitionController.java
@@ -4,6 +4,7 @@ import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeD
 import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeDefUpdateRequest;
 import com.fourthread.ozang.module.domain.clothes.dto.response.ClothesAttributeDefDto;
 import com.fourthread.ozang.module.domain.clothes.service.ClothesAttributeDefinitionService;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,8 @@ public class ClothesAttributeDefinitionController {
 
     private final ClothesAttributeDefinitionService definitionService;
 
-    //TODO 어드민 사용자만 의상 속성을 정의할 수 있다.
+    //TODO 어드민 사용자만 의상 속성을 정의(생성, 수정, 삭제)할 수 있다.
+
     @PostMapping
     public ResponseEntity<ClothesAttributeDefDto> create(
             @RequestBody @Validated ClothesAttributeDefCreateRequest request) {
@@ -32,7 +34,7 @@ public class ClothesAttributeDefinitionController {
 
     @PatchMapping("/{definitionId}")
     public ResponseEntity<ClothesAttributeDefDto> update(
-            @PathVariable UUID definitionId,
+            @PathVariable @NotNull UUID definitionId,
             @RequestBody @Validated ClothesAttributeDefUpdateRequest request) {
 
         ClothesAttributeDefDto response = definitionService.update(definitionId, request);
@@ -40,4 +42,16 @@ public class ClothesAttributeDefinitionController {
                 .status(HttpStatus.OK)
                 .body(response);
     }
+
+    @DeleteMapping("/{definitionId}")
+    public ResponseEntity<ClothesAttributeDefDto> delete(
+            @PathVariable @NotNull UUID definitionId) {
+        ClothesAttributeDefDto response = definitionService.delete(definitionId);
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(response);
+        //TODO 204 인데 바디 값을 보내야함 -> api 스펙 이상하다.
+    }
+
+
 }

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/controller/ClothesAttributeDefinitionController.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/controller/ClothesAttributeDefinitionController.java
@@ -1,16 +1,16 @@
 package com.fourthread.ozang.module.domain.clothes.controller;
 
 import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeDefCreateRequest;
+import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeDefUpdateRequest;
 import com.fourthread.ozang.module.domain.clothes.dto.response.ClothesAttributeDefDto;
 import com.fourthread.ozang.module.domain.clothes.service.ClothesAttributeDefinitionService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/clothes/attribute-defs")
@@ -19,13 +19,25 @@ public class ClothesAttributeDefinitionController {
 
     private final ClothesAttributeDefinitionService definitionService;
 
+    //TODO 어드민 사용자만 의상 속성을 정의할 수 있다.
     @PostMapping
     public ResponseEntity<ClothesAttributeDefDto> create(
-            @RequestBody @Valid ClothesAttributeDefCreateRequest request) {
+            @RequestBody @Validated ClothesAttributeDefCreateRequest request) {
 
         ClothesAttributeDefDto response = definitionService.create(request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
+                .body(response);
+    }
+
+    @PatchMapping("/{definitionId}")
+    public ResponseEntity<ClothesAttributeDefDto> update(
+            @PathVariable UUID definitionId,
+            @RequestBody @Validated ClothesAttributeDefUpdateRequest request) {
+
+        ClothesAttributeDefDto response = definitionService.update(definitionId, request);
+        return ResponseEntity
+                .status(HttpStatus.OK)
                 .body(response);
     }
 }

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/requeset/ClothesAttributeDefUpdateRequest.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/requeset/ClothesAttributeDefUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.fourthread.ozang.module.domain.clothes.dto.requeset;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record ClothesAttributeDefUpdateRequest(
+        @NotBlank String name,
+        @NotEmpty List<@NotBlank String> selectableValues
+) {}

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/entity/ClothesAttributeDefinition.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/entity/ClothesAttributeDefinition.java
@@ -4,6 +4,8 @@ package com.fourthread.ozang.module.domain.clothes.entity;
 import com.fourthread.ozang.module.domain.BaseUpdatableEntity;
 import com.fourthread.ozang.module.domain.clothes.StringListConverter;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,10 +23,14 @@ public class ClothesAttributeDefinition extends BaseUpdatableEntity {
     @Column(nullable = false, unique = true)
     private String name;
 
-
     @Convert(converter = StringListConverter.class)
     @Column(columnDefinition = "TEXT")  // optional
     private List<String> selectableValues = new ArrayList<>();
+
+    public void update(String name, List<String> selectableValues) {
+        this.name = name;
+        this.selectableValues = selectableValues;
+    }
 
 
 /*    //의상속성정의에서 의상속성으로 갈 일이 있나? 아직은 필요없어 보임

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/repository/ClothesAttributeDefinitionRepository.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/repository/ClothesAttributeDefinitionRepository.java
@@ -6,4 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.UUID;
 
 public interface ClothesAttributeDefinitionRepository extends JpaRepository<ClothesAttributeDefinition, UUID> {
+
+    boolean existsByName(String name);
+
+    //수정 중복 체크용 - 자기 자신 제외
+    boolean existsByNameAndIdNot(String name, UUID id);
+
 }

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/service/ClothesAttributeDefinitionService.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/service/ClothesAttributeDefinitionService.java
@@ -9,6 +9,7 @@ import com.fourthread.ozang.module.domain.clothes.mapper.ClothesAttributeDefinit
 import com.fourthread.ozang.module.domain.clothes.repository.ClothesAttributeDefinitionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -19,6 +20,7 @@ public class ClothesAttributeDefinitionService {
     private final ClothesAttributeDefinitionRepository definitionRepository;
     private final ClothesAttributeDefinitionMapper definitionMapper;
 
+    @Transactional
     public ClothesAttributeDefDto create(ClothesAttributeDefCreateRequest request) {
         if (definitionRepository.existsByName(request.name())) {
             throw new IllegalArgumentException("이미 존재하는 속성 이름입니다."); //TODO 커스텀 예외처리
@@ -28,6 +30,7 @@ public class ClothesAttributeDefinitionService {
         return definitionMapper.toDto(save);
     }
 
+    @Transactional
     public ClothesAttributeDefDto update(UUID definitionId, ClothesAttributeDefUpdateRequest request) {
         ClothesAttributeDefinition definition = definitionRepository.findById(definitionId)
                 .orElseThrow(() -> new IllegalArgumentException("속성 정의가 존재하지 않습니다.")); //TODO 커스텀 예외처리
@@ -40,5 +43,12 @@ public class ClothesAttributeDefinitionService {
         return definitionMapper.toDto(definition);
     }
 
-
+    @Transactional
+    public ClothesAttributeDefDto delete(UUID definitionId) {
+        ClothesAttributeDefinition definition = definitionRepository.findById(definitionId)
+                .orElseThrow(() -> new IllegalArgumentException("속성 정의가 존재하지 않습니다.")); //TODO 커스텀 예외처리
+        ClothesAttributeDefDto dto = definitionMapper.toDto(definition);
+        definitionRepository.delete(definition);
+        return dto;
+    }
 }

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/service/ClothesAttributeDefinitionService.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/service/ClothesAttributeDefinitionService.java
@@ -2,6 +2,7 @@ package com.fourthread.ozang.module.domain.clothes.service;
 
 
 import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeDefCreateRequest;
+import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeDefUpdateRequest;
 import com.fourthread.ozang.module.domain.clothes.dto.response.ClothesAttributeDefDto;
 import com.fourthread.ozang.module.domain.clothes.entity.ClothesAttributeDefinition;
 import com.fourthread.ozang.module.domain.clothes.mapper.ClothesAttributeDefinitionMapper;
@@ -9,16 +10,35 @@ import com.fourthread.ozang.module.domain.clothes.repository.ClothesAttributeDef
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class ClothesAttributeDefinitionService {
 
-    private final ClothesAttributeDefinitionRepository repository;
-    private final ClothesAttributeDefinitionMapper mapper;
+    private final ClothesAttributeDefinitionRepository definitionRepository;
+    private final ClothesAttributeDefinitionMapper definitionMapper;
 
     public ClothesAttributeDefDto create(ClothesAttributeDefCreateRequest request) {
+        if (definitionRepository.existsByName(request.name())) {
+            throw new IllegalArgumentException("이미 존재하는 속성 이름입니다."); //TODO 커스텀 예외처리
+        }
         ClothesAttributeDefinition clothesAttributeDefinition = new ClothesAttributeDefinition(request.name(), request.selectableValues());
-        ClothesAttributeDefinition save = repository.save(clothesAttributeDefinition);
-        return mapper.toDto(save);
+        ClothesAttributeDefinition save = definitionRepository.save(clothesAttributeDefinition);
+        return definitionMapper.toDto(save);
     }
+
+    public ClothesAttributeDefDto update(UUID definitionId, ClothesAttributeDefUpdateRequest request) {
+        ClothesAttributeDefinition definition = definitionRepository.findById(definitionId)
+                .orElseThrow(() -> new IllegalArgumentException("속성 정의가 존재하지 않습니다.")); //TODO 커스텀 예외처리
+
+        if (definitionRepository.existsByNameAndIdNot(request.name(), definitionId)) {
+            throw new IllegalArgumentException("해당 속성정의 이름이 이미 존재합니다."); //TODO 커스텀 예외처리
+        }
+
+        definition.update(request.name(), request.selectableValues());
+        return definitionMapper.toDto(definition);
+    }
+
+
 }

--- a/src/test/java/com/fourthread/ozang/module/domain/clothes/service/ClothesAttributeDefinitionServiceTest.java
+++ b/src/test/java/com/fourthread/ozang/module/domain/clothes/service/ClothesAttributeDefinitionServiceTest.java
@@ -1,6 +1,7 @@
 package com.fourthread.ozang.module.domain.clothes.service;
 
 import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeDefCreateRequest;
+import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeDefUpdateRequest;
 import com.fourthread.ozang.module.domain.clothes.dto.response.ClothesAttributeDefDto;
 import com.fourthread.ozang.module.domain.clothes.entity.ClothesAttributeDefinition;
 import com.fourthread.ozang.module.domain.clothes.mapper.ClothesAttributeDefinitionMapper;
@@ -15,11 +16,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class ClothesAttributeDefinitionServiceTest {
@@ -69,6 +74,69 @@ class ClothesAttributeDefinitionServiceTest {
 
         //then
         assertThat(result).isEqualTo(clothesAttributeDefDto);
+    }
+
+    @DisplayName("이미 존재하는 속성 정의 이름으로 등록할 수 없다.")
+    @Test
+    void ClothesAttributeDefCreate_fail_whenNameDuplicated() {
+        // given
+        String name = "두께감";
+        List<String> selectableValues = List.of("얇음", "보통", "두꺼움");
+        ClothesAttributeDefCreateRequest request = new ClothesAttributeDefCreateRequest(name, selectableValues);
+
+        given(repository.existsByName(name)).willReturn(true);
+
+        // when then
+        assertThatThrownBy(() -> service.create(request))
+                .isInstanceOf(IllegalArgumentException.class); //TODO 추후 예외 수정
+        then(repository).should(never()).save(any());
+    }
+
+    @DisplayName("의상 속성 정의를 수정할 수 있다.")
+    @Test
+    void ClothesAttributeDefUpdate() {
+        //given
+        UUID id = clothesAttributeDefinition.getId();
+        ClothesAttributeDefUpdateRequest request = new ClothesAttributeDefUpdateRequest("두께감", List.of("얇음", "보통", "두꺼움"));
+
+        given(repository.findById(id)).willReturn(Optional.of(clothesAttributeDefinition));
+        given(repository.existsByNameAndIdNot("두께감", id)).willReturn(false);
+        given(mapper.toDto(clothesAttributeDefinition)).willReturn(clothesAttributeDefDto);
+
+        //when
+        ClothesAttributeDefDto result = service.update(id, request);
+
+        //then
+        assertThat(result).isEqualTo(clothesAttributeDefDto);
+    }
+
+    @DisplayName("존재하지 않는 속성 정의 ID로 수정할 수 없다.")
+    @Test
+    void update_fail_whenDefinitionNotFound() {
+        //given
+        UUID id = UUID.randomUUID();
+        ClothesAttributeDefUpdateRequest request = new ClothesAttributeDefUpdateRequest("두께감", List.of("얇음", "보통", "두꺼움"));
+
+        given(repository.findById(id)).willReturn(Optional.empty());
+
+        //when then
+        assertThatThrownBy(() -> service.update(id, request))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("이미 존재하는 이름으로 수정할 수 없다.")
+    @Test
+    void update_fail_whenNameIsDuplicated() {
+        //given
+        UUID id = clothesAttributeDefinition.getId();
+        ClothesAttributeDefUpdateRequest request = new ClothesAttributeDefUpdateRequest("촉감", List.of("부드러움", "뻣뻣함"));
+
+        given(repository.findById(id)).willReturn(Optional.of(clothesAttributeDefinition));
+        given(repository.existsByNameAndIdNot("촉감", id)).willReturn(true);
+
+        //when then
+        assertThatThrownBy(() -> service.update(id, request))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/src/test/java/com/fourthread/ozang/module/domain/clothes/service/ClothesAttributeDefinitionServiceTest.java
+++ b/src/test/java/com/fourthread/ozang/module/domain/clothes/service/ClothesAttributeDefinitionServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ClothesAttributeDefinitionServiceTest {
@@ -124,7 +125,7 @@ class ClothesAttributeDefinitionServiceTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @DisplayName("이미 존재하는 이름으로 수정할 수 없다.")
+    @DisplayName("이미 존재하는 속성 정의 이름으로 수정할 수 없다.")
     @Test
     void update_fail_whenNameIsDuplicated() {
         //given
@@ -139,4 +140,33 @@ class ClothesAttributeDefinitionServiceTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @DisplayName("의상 속성 정의를 삭제할 수 있다.")
+    @Test
+    void ClothesAttributeDefDelete() {
+        //given
+        UUID id = clothesAttributeDefinition.getId();
+
+        given(repository.findById(id)).willReturn(Optional.of(clothesAttributeDefinition));
+        given(mapper.toDto(clothesAttributeDefinition)).willReturn(clothesAttributeDefDto);
+
+        //when
+        ClothesAttributeDefDto result = service.delete(id);
+
+        //then
+        assertThat(result).isEqualTo(clothesAttributeDefDto);
+        verify(repository).delete(clothesAttributeDefinition);
+    }
+
+    @DisplayName("존재하지 않는 속성 정의는 삭제할 수 없다.")
+    @Test
+    void delete_fail_whenDefinitionNotFound() {
+        //given
+        UUID id = UUID.randomUUID();
+        given(repository.findById(id)).willReturn(Optional.empty());
+
+        //when then
+        assertThatThrownBy(() -> service.delete(id))
+                .isInstanceOf(IllegalArgumentException.class);
+        verify(repository, never()).delete(any());
+    }
 }


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

의상 속성 정의 삭제 구현

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->
- [DELETE] /api/clothes/attribute-defs/{definitionId} - 의상 속성 정의 삭제


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 의상 속성 정의 삭제 엔트포인트 구현
- ClothesAttributeDefinitionService delete 성공, 실패 단위 테스트 추가

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [ ] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #26 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
스웨거에서 삭제 성공 시에는 응답 바디를 가질 수 없는 204 No Content를 반환하라고 명시되어 있는데,
동시에 반환 DTO도 정의돼 있어서 서로 모순되는 부분이 있네요.
추후에 다시 리펙터링 하겠습니다.