### PR TITLE
Feat/#28/clothes attri list

### DIFF
--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/controller/ClothesAttributeDefinitionController.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/controller/ClothesAttributeDefinitionController.java
@@ -3,6 +3,7 @@ package com.fourthread.ozang.module.domain.clothes.controller;
 import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeDefCreateRequest;
 import com.fourthread.ozang.module.domain.clothes.dto.requeset.ClothesAttributeDefUpdateRequest;
 import com.fourthread.ozang.module.domain.clothes.dto.response.ClothesAttributeDefDto;
+import com.fourthread.ozang.module.domain.clothes.dto.response.CursorPageResponseClothesAttributeDefDto;
 import com.fourthread.ozang.module.domain.clothes.service.ClothesAttributeDefinitionService;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -53,5 +54,19 @@ public class ClothesAttributeDefinitionController {
         //TODO 204 인데 바디 값을 보내야함 -> api 스펙 이상하다.
     }
 
-
+    @GetMapping
+    public ResponseEntity<CursorPageResponseClothesAttributeDefDto> findAll(
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) UUID idAfter,
+            @RequestParam(defaultValue = "20") int limit,
+            @RequestParam(defaultValue = "name") String sortBy,
+            @RequestParam(defaultValue = "ASCENDING") String sortDirection,
+            @RequestParam(required = false) String keywordLike
+    ) {
+        CursorPageResponseClothesAttributeDefDto result =
+                definitionService.findAll(cursor, idAfter, limit, sortBy, sortDirection, keywordLike);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(result);
+    }
 }

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/response/CursorPageResponseClothesAttributeDefDto.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/response/CursorPageResponseClothesAttributeDefDto.java
@@ -1,0 +1,15 @@
+package com.fourthread.ozang.module.domain.clothes.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+public record CursorPageResponseClothesAttributeDefDto(
+        List<ClothesAttributeDefDto> data,
+        String nextCursor,
+        UUID nextIdAfter,
+        boolean hasNext,
+        int totalCount,
+        String sortBy,
+        String sortDirection
+) {
+}

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/response/SortBy.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/response/SortBy.java
@@ -1,0 +1,13 @@
+package com.fourthread.ozang.module.domain.clothes.dto.response;
+
+public enum SortBy {
+    NAME, ID;
+
+    public static SortBy from(String value) {
+        try {
+            return SortBy.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("지원하지 않는 정렬 필드: " + value); //TODO 커스텀 예외처리
+        }
+    }
+}

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/response/SortDirection.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/response/SortDirection.java
@@ -1,0 +1,17 @@
+package com.fourthread.ozang.module.domain.clothes.dto.response;
+
+public enum SortDirection {
+    ASCENDING, DESCENDING;
+
+    public static SortDirection from(String value) {
+        try {
+            return SortDirection.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("지원하지 않는 정렬 방향: " + value); //TODO 커스텀 예외처리
+        }
+    }
+
+    public boolean isDescending() {
+        return this == DESCENDING;
+    }
+}

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/repository/ClothesAttributeDefinitionRepository.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/repository/ClothesAttributeDefinitionRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface ClothesAttributeDefinitionRepository extends JpaRepository<ClothesAttributeDefinition, UUID> {
+public interface ClothesAttributeDefinitionRepository extends JpaRepository<ClothesAttributeDefinition, UUID>, ClothesAttributeDefinitionRepositoryCustom {
 
     boolean existsByName(String name);
 

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/repository/ClothesAttributeDefinitionRepositoryCustom.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/repository/ClothesAttributeDefinitionRepositoryCustom.java
@@ -1,0 +1,23 @@
+package com.fourthread.ozang.module.domain.clothes.repository;
+
+import com.fourthread.ozang.module.domain.clothes.dto.response.SortBy;
+import com.fourthread.ozang.module.domain.clothes.dto.response.SortDirection;
+import com.fourthread.ozang.module.domain.clothes.entity.ClothesAttributeDefinition;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ClothesAttributeDefinitionRepositoryCustom {
+
+    public List<ClothesAttributeDefinition> findAllByCondition(
+            String cursorName,
+            UUID idAfter,
+            int limit,
+            SortBy sortBy,
+            SortDirection sortDirection,
+            String keywordLike
+    );
+
+    public int countByCondition(String keywordLike);
+
+}

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/repository/ClothesAttributeDefinitionRepositoryImpl.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/repository/ClothesAttributeDefinitionRepositoryImpl.java
@@ -1,0 +1,98 @@
+package com.fourthread.ozang.module.domain.clothes.repository;
+
+import com.fourthread.ozang.module.domain.clothes.dto.response.SortBy;
+import com.fourthread.ozang.module.domain.clothes.dto.response.SortDirection;
+import com.fourthread.ozang.module.domain.clothes.entity.ClothesAttributeDefinition;
+import com.fourthread.ozang.module.domain.clothes.entity.QClothesAttributeDefinition;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.fourthread.ozang.module.domain.clothes.entity.QClothesAttributeDefinition.*;
+
+@RequiredArgsConstructor
+public class ClothesAttributeDefinitionRepositoryImpl implements ClothesAttributeDefinitionRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<ClothesAttributeDefinition> findAllByCondition(
+            String cursorName,
+            UUID idAfter,
+            int limit,
+            SortBy sortBy,
+            SortDirection sortDirection,
+            String keywordLike
+    ) {
+        QClothesAttributeDefinition q = clothesAttributeDefinition;
+
+        BooleanBuilder condition = new BooleanBuilder();
+
+        if (keywordLike != null && !keywordLike.isBlank()) {
+            condition.and(q.name.containsIgnoreCase(keywordLike));
+        }
+
+        // 커서 조건
+        if (cursorName != null) {
+            BooleanBuilder cursorCondition = new BooleanBuilder();
+            switch (sortBy) {
+                case NAME -> {
+                    if (sortDirection.isDescending()) {
+                        cursorCondition.or(q.name.lt(cursorName));
+                        if (idAfter != null)
+                            cursorCondition.or(q.name.eq(cursorName).and(q.id.lt(idAfter)));
+                    } else {
+                        cursorCondition.or(q.name.gt(cursorName));
+                        if (idAfter != null)
+                            cursorCondition.or(q.name.eq(cursorName).and(q.id.gt(idAfter)));
+                    }
+                }
+                case ID -> {
+                    UUID cursorId = UUID.fromString(cursorName); //서비스에서 이미 검증
+                    if (sortDirection.isDescending()) {
+                        cursorCondition.or(q.id.lt(cursorId));
+                    } else {
+                        cursorCondition.or(q.id.gt(cursorId));
+                    }
+                }
+            }
+            condition.and(cursorCondition);
+        }
+
+        OrderSpecifier<?> order = getOrderSpecifier(q, sortBy, sortDirection);
+
+        return queryFactory
+                .selectFrom(q)
+                .where(condition)
+                .orderBy(order)
+                .limit(limit)
+                .fetch();
+    }
+
+    public int countByCondition(String keywordLike) {
+        QClothesAttributeDefinition q = clothesAttributeDefinition;
+
+        BooleanBuilder condition = new BooleanBuilder();
+        if (keywordLike != null && !keywordLike.isBlank()) {
+            condition.and(q.name.containsIgnoreCase(keywordLike));
+        }
+
+        return Math.toIntExact(
+                queryFactory
+                        .select(q.count())
+                        .from(q)
+                        .where(condition)
+                        .fetchOne()
+        );
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(QClothesAttributeDefinition q, SortBy sortBy, SortDirection direction) {
+        return switch (sortBy) {
+            case NAME -> direction.isDescending() ? q.name.desc() : q.name.asc();
+            case ID -> direction.isDescending() ? q.id.desc() : q.id.asc();
+        };
+    }
+}


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

의상 속성 정의 목록을 커서 기반 페이지네이션 방식으로 조회하는 API를 구현했습니다.
정렬 조건(sortBy, sortDirection) 및 키워드 필터링(keywordLike) 적용.

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->

- [GET] /api/clothes/attribute-defs


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- ClothesAttributeDefinitionController.findAll() 엔드포인트 구현
- 커서 기반 페이징 로직 및 정렬 방식 처리
- SortBy, SortDirection enum 구현 및 유효성 처리

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<img width="850" alt="image" src="https://github.com/user-attachments/assets/afa4d573-b4b1-4999-b946-ab12aaac6a18" />

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [ ] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #28 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
