### PR TITLE
chore: GitHub Actions KST 타임존 설정 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GRADLE_OPTS: -Dorg.gradle.daemon=false
+      TZ: Asia/Seoul
+      JAVA_OPTS: -Duser.timezone=Asia/Seoul
       KAKAO_API_KEY: ${{ secrets.KAKAO_API_KEY }}
       WEATHER_API_KEY: ${{ secrets.WEATHER_API_KEY }}
       JWT_SECRET : ${{secrets.JWT_SECRET}}
@@ -18,12 +20,17 @@ jobs:
       ADMIN_PASSWORD : ${{secrets.ADMIN_PASSWORD}}
       ADMIN_EMAIL : ${{secrets.ADMIN_EMAIL}}
 
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Set timezone to KST
+        run: |
+          sudo timedatectl set-timezone Asia/Seoul
+          echo "Current time: $(date)"
+          echo "Java timezone will be set to: Asia/Seoul"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -34,6 +41,18 @@ jobs:
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
+      - name: Verify timezone and run tests with JaCoCo
+        run: |
+          echo "=== Timezone Verification ==="
+          echo "System timezone: $(timedatectl show --property=Timezone --value)"
+          echo "Current date/time: $(date)"
+          echo "Java timezone: $JAVA_OPTS"
+          echo "=========================="
+          ./gradlew clean test jacocoTestReport
+        env:
+          TZ: Asia/Seoul
+          JAVA_TOOL_OPTIONS: -Duser.timezone=Asia/Seoul
 
       - name: Run tests with JaCoCo
         run: |


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
KST 타임존 기준으로 진행된 API 호출 과정이 Git Actions의 타임존과의 불일치로 실패하여 workflow 파일에 KST 타임존 설정을 추가하였습니다.

### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 환경 변수 추가
```yaml
env:
  # 새로 추가된 타임존 설정
  TZ: Asia/Seoul
  JAVA_OPTS: -Duser.timezone=Asia/Seoul
```
- 시스템 타임존 설정 단계 추가
```yaml
- name: Set timezone to KST
  run: |
    sudo timedatectl set-timezone Asia/Seoul
    echo "Current time: $(date)"
    echo "Java timezone will be set to: Asia/Seoul"
```
- 테스트 실행 단계 개선
타임존 확인 로그 추가: 문제 진단을 위한 디버깅 정보
명시적 환경 변수 설정: JAVA_TOOL_OPTIONS로 JVM 타임존 재확인

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #77 
