### PR TITLE
Hotfix/#83/clothes update

### DIFF
--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/requeset/ClothesCreateRequest.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/requeset/ClothesCreateRequest.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 public record ClothesCreateRequest(
 
-        //@NotNull(message = "소유자 ID는 필수입니다.")
+        @NotNull(message = "소유자 ID는 필수입니다.")
         UUID ownerId,
 
         @NotBlank(message = "이름은 필수 입력값입니다.")
@@ -21,9 +21,9 @@ public record ClothesCreateRequest(
         @NotNull(message = "의상 타입은 필수입니다.")
         ClothesType type,
 
-        //@NotNull(message = "속성 목록은 필수입니다.")
-        //@Size(min = 1, message = "적어도 하나 이상의 속성이 필요합니다.")
-        //@Validated
+        @NotNull(message = "속성 목록은 필수입니다.")
+        @Size(min = 1, message = "적어도 하나 이상의 속성이 필요합니다.")
+        @Validated
         List<ClothesAttributeDto> attributes
 ) {
 }

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/requeset/ClothesUpdateRequest.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/requeset/ClothesUpdateRequest.java
@@ -2,7 +2,6 @@ package com.fourthread.ozang.module.domain.clothes.dto.requeset;
 
 import com.fourthread.ozang.module.domain.clothes.dto.response.ClothesAttributeDto;
 import com.fourthread.ozang.module.domain.clothes.entity.ClothesType;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import org.springframework.validation.annotation.Validated;
@@ -11,10 +10,7 @@ import java.util.List;
 
 public record ClothesUpdateRequest(
 
-        @NotBlank(message = "이름은 필수 입력값입니다.")
         String name,
-
-        @NotNull(message = "의상 타입은 필수입니다.")
         ClothesType type,
 
         @NotNull(message = "속성 목록은 필수입니다.")

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/response/ClothesAttributeDto.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/dto/response/ClothesAttributeDto.java
@@ -8,9 +8,9 @@ import java.util.UUID;
 
 public record ClothesAttributeDto(
 
-        //@NotNull(message = "속성 정의 ID는 필수입니다.")
+        @NotNull(message = "속성 정의 ID는 필수입니다.")
         UUID definitionId,
 
-        //@NotBlank(message = "속성 값은 필수입니다.")
+        @NotBlank(message = "속성 값은 필수입니다.")
         String value
 ) {}

--- a/src/main/java/com/fourthread/ozang/module/domain/clothes/entity/Clothes.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/clothes/entity/Clothes.java
@@ -17,13 +17,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Clothes extends BaseUpdatableEntity {
-
-    //@ManyToOne(fetch = FetchType.LAZY)
-    //@JoinColumn(name = "owner_id")
-    //private User owner;
-
-    //굳이 연관관계 필요없이 아이디만 가져도 될듯
-    //옷에서 유저정보를 얻진 않음
+    
     @Column(nullable = false)
     private UUID ownerId;
 
@@ -48,8 +42,11 @@ public class Clothes extends BaseUpdatableEntity {
         clothesAttribute.assignClothes(this);
     }
 
-    public void updateNameAndType(String name, ClothesType type) {
+    public void updateName(String name) {
         this.name = name;
+    }
+
+    public void updateType(ClothesType type) {
         this.type = type;
     }
 

--- a/src/test/java/com/fourthread/ozang/module/domain/clothes/service/ClothesServiceTest.java
+++ b/src/test/java/com/fourthread/ozang/module/domain/clothes/service/ClothesServiceTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -34,8 +35,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ClothesServiceTest {
@@ -353,4 +353,75 @@ class ClothesServiceTest {
         )).isInstanceOf(IllegalArgumentException.class);
     }
 
+    @DisplayName("비어 있는 이미지 파일은 업로드되지 않는다.")
+    @Test
+    void image_is_empty_then_not_uploaded() {
+        //given
+        MultipartFile emptyImage = mock(MultipartFile.class);
+        given(emptyImage.isEmpty()).willReturn(true);
+
+        ClothesAttributeDto attributeDto = new ClothesAttributeDto(definitionId, "화이트");
+        ClothesCreateRequest request = new ClothesCreateRequest(
+                ownerId,
+                "여름 셔츠",
+                ClothesType.TOP,
+                List.of(attributeDto)
+        );
+
+        given(userRepository.existsById(ownerId)).willReturn(true);
+        given(definitionRepository.findById(definitionId)).willReturn(Optional.of(definition));
+        given(clothesMapper.toDto(any())).willReturn(clothesDto);
+
+        //when
+        ClothesDto result = clothesService.create(request, emptyImage);
+
+        //then
+        assertThat(result).isEqualTo(clothesDto);
+        then(imageService).should(never()).uploadImage(any());
+    }
+
+    @DisplayName("옷 이름이 null이면 이름 변경은 수행되지 않는다.")
+    @Test
+    void update_name_should_be_skipped_if_null_or_blank() {
+        Clothes clothes = mock(Clothes.class);
+
+        ClothesService service = new ClothesService(
+                clothesRepository, userRepository, definitionRepository, clothesMapper, imageService);
+
+        //when
+        ReflectionTestUtils.invokeMethod(service, "updateNameAndType", clothes, null, ClothesType.TOP);
+
+        //then
+        then(clothes).should(never()).updateName(any());
+    }
+
+    @DisplayName("옷 이름이 공백이면 이름 변경은 수행되지 않는다.")
+    @Test
+    void update_name_should_be_skipped_if_blank() {
+        Clothes clothes = mock(Clothes.class);
+
+        ClothesService service = new ClothesService(
+                clothesRepository, userRepository, definitionRepository, clothesMapper, imageService);
+
+        //when
+        ReflectionTestUtils.invokeMethod(service, "updateNameAndType", clothes, "   ", ClothesType.TOP);
+
+        //then
+        then(clothes).should(never()).updateName(any());
+    }
+
+    @DisplayName("의상 타입이 null이면 타입 변경은 수행되지 않는다.")
+    @Test
+    void update_type_should_be_skipped_if_null() {
+        Clothes clothes = mock(Clothes.class);
+
+        ClothesService service = new ClothesService(
+                clothesRepository, userRepository, definitionRepository, clothesMapper, imageService);
+
+        //when
+        ReflectionTestUtils.invokeMethod(service, "updateNameAndType", clothes, "새 이름", null);
+
+        //then
+        then(clothes).should(never()).updateType(any());
+    }
 }


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->

의상 update 오류 수정하였습니다.

### 구현된 API 엔드포인트
<!-- 구현한 API 엔드포인트 목록을 작성해주세요 -->
<!-- 예시:
- GET /api/employees - 직원 목록 조회
- POST /api/employees - 직원 등록
- GET /api/employees/{id} - 직원 상세 조회
- PATCH /api/employees/{id} - 직원 정보 수정
- DELETE /api/employees/{id} - 직원 삭제
- GET /api/employees/stats/trend - 직원 수 추이 조회
- GET /api/employees/stats/distribution - 직원 분포 조회
- GET /api/employees/count - 직원 수 조회 -->
- [PATCH] /api/clothes/{clothesId}

### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- ClothesCreateRequest name, type null 허용
- clothes create 생성시 ownerId 검증 추가
- 서비스 단위 테스트 추가


## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [x] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->
<img width="791" alt="image" src="https://github.com/user-attachments/assets/ad3af751-fb6b-4a9e-9a7c-2e01df23f51e" />
</br>
name, type 값을 넘기지 않고 테스트하였습니다.

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #83 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
의상을 수정할 때 name, type은 수정하지 않은 경우 requset에 인자가 포함되어 있지 않아 서버에서 null로 받고 있었습니다. 
그 상태에서 null 검증을 하고 있어 오류가 발생하였습니다.