### PR TITLE
refactor :Profile 업데이트 시 null 값이 오면 변경 안되도록 설정 완료

### DIFF
--- a/src/main/java/com/fourthread/ozang/module/domain/user/entity/Profile.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/user/entity/Profile.java
@@ -56,12 +56,12 @@ public class Profile extends BaseUpdatableEntity {
 
   public void updateProfile(String name, Gender gender, LocalDate birthDate,
       Location location, Integer temperatureSensitivity, String profileImageUrl) {
-    this.name = name;
-    this.gender = gender;
-    this.birthDate = birthDate;
-    this.location = location;
-    this.temperatureSensitivity = temperatureSensitivity;
-    this.profileImageUrl = profileImageUrl;
+    if (name != null) this.name = name;
+    if (gender != null) this.gender = gender;
+    if (birthDate != null) this.birthDate = birthDate;
+    if (location != null) this.location = location;
+    if (temperatureSensitivity != null) this.temperatureSensitivity = temperatureSensitivity;
+    if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
   }
 
   public void setUser(User user) {


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
- 기존 프로필에서 값을 변경하지 않고 다시 저장을 누르게 되면 전체 항복이 null로 변경되는 버그가 있었습니다.
- 해당 버그를 없애기 위해 updateProfile 메서드에서 null을 받게 되면 해당 값은 변경되지 않도록 간단히 변경하였습니다.

### 구현된 API 엔드포인트
- POST /api/employees - 직원 등록


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- ```
  public void updateProfile(String name, Gender gender, LocalDate birthDate,
      Location location, Integer temperatureSensitivity, String profileImageUrl) {
    if (name != null) this.name = name;
    if (gender != null) this.gender = gender;
    if (birthDate != null) this.birthDate = birthDate;
    if (location != null) this.location = location;
    if (temperatureSensitivity != null) this.temperatureSensitivity = temperatureSensitivity;
    if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
  }

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/dfc1267f-1de3-4c1a-b8ad-012404c759cc)


## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #87 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
