### PR TITLE
refactor : Redis 데이터 저장 시 TTL 유효성 검사 추가

### DIFF
--- a/src/main/java/com/fourthread/ozang/module/domain/security/redis/RedisDao.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/redis/RedisDao.java
@@ -16,9 +16,12 @@ public class RedisDao {
   }
 
   // 만료 시간이 있는 데이터 저장
-  public void setValues(String key, String data, Duration duration) {
-    log.debug("[RedisDao] Redis 저장");
-    redisTemplate.opsForValue().set(key, data, duration);
+  public void setValues(String key, String value, Duration ttl) {
+    if (ttl != null && !ttl.isNegative() && !ttl.isZero()) {
+      redisTemplate.opsForValue().set(key, value, ttl);
+    } else {
+      log.warn("유효하지 않은 TTL 값: {} → TTL 없이 저장 시도", ttl);
+    }
   }
 
   // 데이터 조회

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,7 +113,7 @@ kakao:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration-seconds: 60 #10분
+  access-token-expiration-seconds: 600 #10분
   refresh-token-expiration-seconds: 86400 #24시간
 
 admin:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,7 +113,7 @@ kakao:
 
 jwt:
   secret: ${JWT_SECRET}
-  access-token-expiration-seconds: 600 #10분
+  access-token-expiration-seconds: 60 #10분
   refresh-token-expiration-seconds: 86400 #24시간
 
 admin:


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
- 기존 코드에서 Redis에 데이터를 저장할 때 TTL이 유효한지 확인하지 않았습니다.
- 따라서 아래 사진을 보면 Redis에서 Exception이 발생하게 되었고 해당 Exception은 TTL이 만료된 토큰을 저장하려고 하다 발생한 것임을 알게 되었습니다.
- 따라서 유효성 검사를 통해 TTL이 지난 토큰은 Redis에 저장을 시도하지 않도록 수정하였습니다.


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
![image](https://github.com/user-attachments/assets/f6108379-6c70-4fd2-bb61-d9cb198ac94b)

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #89 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
- 해당 에러에 대해 알려주셔서 감사합니다!
