### PR TITLE
Feat/#91/refresh redis refactor

### DIFF
--- a/src/main/java/com/fourthread/ozang/module/domain/security/jwt/JwtBlacklist.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/jwt/JwtBlacklist.java
@@ -19,7 +19,7 @@ public class JwtBlacklist {
 
   public void put(String token, Instant expirationTime) {
     Duration ttl = Duration.between(Instant.now(), expirationTime);
-    redisDao.setValue("blackList:" + token, "", ttl);
+    redisDao.setValue("blackList:" + token, token, ttl);
     log.info("[JwtBlacklist] 블랙리스트 등록 - 만료 시간: {}", expirationTime);
   }
 

--- a/src/main/java/com/fourthread/ozang/module/domain/security/jwt/JwtBlacklist.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/jwt/JwtBlacklist.java
@@ -1,6 +1,5 @@
 package com.fourthread.ozang.module.domain.security.jwt;
 
-import com.fourthread.ozang.module.domain.security.jwt.dto.type.TokenType;
 import com.fourthread.ozang.module.domain.security.redis.RedisDao;
 import java.time.Duration;
 import java.time.Instant;
@@ -18,9 +17,9 @@ public class JwtBlacklist {
 
   private final RedisDao redisDao;
 
-  public void put(String token, Instant expirationTime, TokenType tokenType) {
+  public void put(String token, Instant expirationTime) {
     Duration ttl = Duration.between(Instant.now(), expirationTime);
-    redisDao.setValues("blacklist:" + token, tokenType.toString(), ttl);
+    redisDao.setValue("blackList:" + token, "", ttl);
     log.info("[JwtBlacklist] 블랙리스트 등록 - 만료 시간: {}", expirationTime);
   }
 

--- a/src/main/java/com/fourthread/ozang/module/domain/security/jwt/JwtService.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/jwt/JwtService.java
@@ -5,7 +5,6 @@ import com.fourthread.ozang.module.common.exception.ErrorCode;
 import com.fourthread.ozang.module.domain.security.jwt.dto.data.JwtDto;
 import com.fourthread.ozang.module.domain.security.jwt.dto.data.JwtPayloadDto;
 import com.fourthread.ozang.module.domain.security.jwt.dto.response.JwtTokenResponse;
-import com.fourthread.ozang.module.domain.security.jwt.dto.type.TokenType;
 import com.fourthread.ozang.module.domain.security.redis.RedisDao;
 import com.fourthread.ozang.module.domain.user.dto.type.Role;
 import com.fourthread.ozang.module.domain.user.exception.UserException;
@@ -56,7 +55,7 @@ public class JwtService {
     JwtDto accessJwtDto = generateJwtDto(payloadDto, accessTokenValiditySeconds);
     JwtDto refreshJwtDto = generateJwtDto(payloadDto, refreshTokenValiditySeconds);
 
-    redisDao.setValues("refresh:" + payloadDto.email(), refreshJwtDto.token(), Duration.ofSeconds(refreshTokenValiditySeconds));
+    redisDao.setValue("refresh:" + payloadDto.email(), refreshJwtDto.token(), Duration.ofSeconds(refreshTokenValiditySeconds));
     log.info("[JwtService] 토큰 발급 완료 -> AccessToken 만료 시간 : {}, RefreshToken 만료 시간: {}", accessJwtDto.exp(), refreshJwtDto.exp());
 
     return new JwtTokenResponse(accessJwtDto.token(),
@@ -149,10 +148,6 @@ public class JwtService {
     String key = "refresh:" + jwtDto.payloadDto().email();
 
     redisDao.delete(key);
-
-    if (!jwtDto.isExpired()) {
-      jwtBlacklist.put(refreshToken, jwtDto.exp(), TokenType.REFRESH);
-    }
   }
 
   @Transactional
@@ -194,7 +189,7 @@ public class JwtService {
 
   public void invalidateAccessToken(String accessToken) {
     JwtDto jwtDto = parse(accessToken);
-    jwtBlacklist.put(accessToken, jwtDto.exp(), TokenType.ACCESS);
+    jwtBlacklist.put(accessToken, jwtDto.exp());
     log.info("[JwtService - invalidateAccessToken] AccessToken 블랙리스트 등록 - 만료 시간 : {}", jwtDto.exp());
   }
 }

--- a/src/main/java/com/fourthread/ozang/module/domain/security/jwt/dto/type/TokenType.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/jwt/dto/type/TokenType.java
@@ -1,5 +1,0 @@
-package com.fourthread.ozang.module.domain.security.jwt.dto.type;
-
-public enum TokenType {
-  REFRESH, ACCESS
-}

--- a/src/main/java/com/fourthread/ozang/module/domain/security/redis/RedisDao.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/redis/RedisDao.java
@@ -16,7 +16,7 @@ public class RedisDao {
   }
 
   // 만료 시간이 있는 데이터 저장
-  public void setValues(String key, String value, Duration ttl) {
+  public void setValue(String key, String value, Duration ttl) {
     if (ttl != null && !ttl.isNegative() && !ttl.isZero()) {
       redisTemplate.opsForValue().set(key, value, ttl);
     } else {


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
- Access 토큰은 만료 시간이 짧지만 탈취를 당했을 때 유효 시간이 남았다면 로그인이 가능하다는 문제가 존재합니다.
- 이 문제를 해결하기 위해 blacklist라는 것을 사용하게 되었습니다.
- 하지만 refresh 토큰도 balcklist에 담기고 있었고 refresh는 이미 redis에 저장되어 관리되고 있었기 때문에 refresh 토큰은 blacklist에 저장되지 않도록 수정했습니다.

### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- 
- 
- 

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [x] 코딩, 커밋 컨벤션 준수
- [x] 모든 테스트 통과
- [x] API 명세 준수
- [x] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #91 