### PR TITLE
feat : 사용자 인증 로직 변경

### DIFF
--- a/src/main/java/com/fourthread/ozang/module/domain/security/config/SecurityConfig.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/config/SecurityConfig.java
@@ -63,7 +63,6 @@ public class SecurityConfig {
             .requestMatchers(HttpMethod.POST, SecurityMatchers.LOGIN).permitAll()
             .requestMatchers(HttpMethod.POST, SecurityMatchers.LOGOUT).permitAll()
             .requestMatchers(HttpMethod.POST, SecurityMatchers.REFRESH).permitAll()
-            .requestMatchers(HttpMethod.GET, SecurityMatchers.ME).permitAll()
             .requestMatchers(HttpMethod.POST, SecurityMatchers.RESET_PASSWORD).permitAll()
             .requestMatchers(HttpMethod.GET, SecurityMatchers.CSRF_TOKEN).permitAll()
             .requestMatchers(SecurityMatchers.H2_CONSOLE).permitAll()

--- a/src/main/java/com/fourthread/ozang/module/domain/security/controller/AuthController.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/controller/AuthController.java
@@ -1,17 +1,23 @@
 package com.fourthread.ozang.module.domain.security.controller;
 
 import com.fourthread.ozang.module.domain.security.jwt.JwtService;
+import com.fourthread.ozang.module.domain.security.jwt.dto.data.JwtPayloadDto;
 import com.fourthread.ozang.module.domain.security.jwt.dto.response.JwtTokenResponse;
+import com.fourthread.ozang.module.domain.security.userdetails.UserDetailsImpl;
+import com.fourthread.ozang.module.domain.user.dto.response.MeResponse;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthentication;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import com.fourthread.ozang.module.domain.user.dto.request.ResetPasswordRequest;
 import com.fourthread.ozang.module.domain.user.service.UserService;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,24 +35,18 @@ public class AuthController {
   private final JwtService jwtService;
   private final UserService userService;
 
-  // 리프레시 토큰을 이용해서 엑세스 토큰을 조회
   @GetMapping("/me")
-  public ResponseEntity<String> me(
-      @CookieValue(value = "refresh_token", required = false) String refreshToken) {
+  public ResponseEntity<MeResponse> me(
+      @AuthenticationPrincipal UserDetailsImpl userDetails
+  ){
 
-    if (refreshToken == null || refreshToken.trim().isEmpty()) {
-      log.warn("[AuthController] refresh_token 쿠키가 없습니다. 로그인이 필요합니다.");
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-          .body("Authentication required. Please login first.");
-    }
+    JwtPayloadDto payloadDto = userDetails.getPayloadDto();
 
-    try {
-      JwtTokenResponse jwtToken = jwtService.refreshJwtToken(refreshToken);
-      return ResponseEntity.status(HttpStatus.OK).body(jwtToken.accessToken());
-    } catch (Exception e) {
-      return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-          .body("Invalid refresh token. Please login again.");
-    }
+    MeResponse response = new MeResponse(payloadDto.userId(), payloadDto.email(), payloadDto.name(),
+        payloadDto.role());
+
+    return ResponseEntity.ok(response);
+
   }
 
   // 리프레시 토큰을 이용해서 리프레시 토큰과 엑세스 토큰을 재발급 받는다

--- a/src/main/java/com/fourthread/ozang/module/domain/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/filter/JwtAuthenticationFilter.java
@@ -104,7 +104,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       if (pattern.equals(SecurityMatchers.LOGOUT) && !HttpMethod.POST.matches(method)) continue;
       if (pattern.equals(SecurityMatchers.SIGN_UP) && !HttpMethod.POST.matches(method)) continue;
       if (pattern.equals(SecurityMatchers.REFRESH) && !HttpMethod.POST.matches(method)) continue;
-      if (pattern.equals(SecurityMatchers.ME) && !HttpMethod.GET.matches(method)) continue;
 
       if (pathPattern.matches(PathContainer.parsePath(path))) {
         return true;
@@ -117,7 +116,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       SecurityMatchers.LOGIN,
       SecurityMatchers.LOGOUT,
       SecurityMatchers.H2_CONSOLE,
-      SecurityMatchers.ME,
       SecurityMatchers.SIGN_UP,
       SecurityMatchers.REFRESH
   };

--- a/src/main/java/com/fourthread/ozang/module/domain/security/jwt/dto/type/SecurityMatchers.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/security/jwt/dto/type/SecurityMatchers.java
@@ -5,7 +5,6 @@ public class SecurityMatchers {
   public static final String LOGIN = "/api/auth/sign-in";
   public static final String LOGOUT = "/api/auth/sign-out";
   public static final String H2_CONSOLE = "/h2-console/**";
-  public static final String ME = "/api/auth/me";
   public static final String SIGN_UP = "/api/users";
   public static final String REFRESH = "/api/auth/refresh";
   public static final String OAUTH2 = "/api/oauth2/**";

--- a/src/main/java/com/fourthread/ozang/module/domain/user/dto/data/UserDto.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/user/dto/data/UserDto.java
@@ -1,6 +1,5 @@
 package com.fourthread.ozang.module.domain.user.dto.data;
 
-import com.fourthread.ozang.module.domain.security.jwt.dto.data.JwtPayloadDto;
 import com.fourthread.ozang.module.domain.user.dto.type.Items;
 import com.fourthread.ozang.module.domain.user.dto.type.Role;
 import java.time.LocalDateTime;

--- a/src/main/java/com/fourthread/ozang/module/domain/user/dto/response/MeResponse.java
+++ b/src/main/java/com/fourthread/ozang/module/domain/user/dto/response/MeResponse.java
@@ -1,0 +1,13 @@
+package com.fourthread.ozang.module.domain.user.dto.response;
+
+import com.fourthread.ozang.module.domain.user.dto.type.Role;
+import java.util.UUID;
+
+public record MeResponse(
+    UUID userId,
+    String email,
+    String name,
+    Role role
+) {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,7 +91,7 @@ kakao:
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration-seconds: 600 #10분
-  refresh-token-expiration-seconds: 86400 #24시간
+  refresh-token-expiration-seconds: 10800 # 3시간
 
 admin:
   username: ${ADMIN_USERNAME}

--- a/src/test/java/com/fourthread/ozang/module/domain/security/SecurityTest.java
+++ b/src/test/java/com/fourthread/ozang/module/domain/security/SecurityTest.java
@@ -1,6 +1,7 @@
 package com.fourthread.ozang.module.domain.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import org.springframework.test.context.ActiveProfiles;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -33,7 +34,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-@Profile("test")
+@ActiveProfiles("test")
 @Transactional
 @SpringBootTest(
     properties = {


### PR DESCRIPTION
## 구현 내용
<!-- 구현한 기능에 대한 간략한 설명을 작성해주세요 -->
- 초기 프론트엔드는 `/api/auth/me` API 호출 시 Access 토큰을 응답으로 받음.
- 프론트에서는 이 Access 토큰을 파싱해 사용자 정보를 추출하고, 이를 `zustand` 스토어에 저장한다.
- https://shimmering-drifter-eef.notion.site/2395046d9f3c80b5a232e993fffaf29e

### 구현된 API 엔드포인트
- GET /api/auth/me - 사용자 인증


### 주요 변경사항
<!-- 주요 변경사항을 작성해주세요 -->
- `/api/auth/me`는 인증된 사용자의 정보 (예: id, email, name, role)만 반환.
- Access 토큰 관련 처리는 `/refresh` API에서만 수행.
- 클라이언트는 Access 토큰 저장/갱신만 책임지고, 사용자 정보는 /me API를 통해 안전하게 조회함. 
- 이와 같이 구현하게 된다면 Stateless한 JWT 토큰 인증 방식을 유지할 수 있게 된다.
- Refersh 토큰 만료시간을 24시간으로 했는데 로그인 문제를 확인해보기 위해 3시간으로 수정하였습니다.

## 테스트 완료 사항
<!-- 테스트한 항목에 체크(x)해주세요 -->
- [ ] 단위 테스트
- [ ] 통합 테스트
- [x] API 테스트 (Swagger/Postman 등)
- [ ] 기타 테스트

## 스크린샷
<!-- 필요한 경우 관련 스크린샷을 첨부해주세요 -->

## 체크리스트
<!-- 제출 전 확인해야 할 사항들입니다 -->
- [ ] 코딩, 커밋 컨벤션 준수
- [ ] 모든 테스트 통과
- [ ] API 명세 준수
- [ ] 불필요한 로그, 주석, 미사용 코드 제거

## 관련 이슈
<!-- 관련 이슈를 연결하세요. 이슈가 자동으로 닫히게 하려면 closes/fixes/resolves 키워드를 사용하세요 -->
closes #159 

## 추가 코멘트 (선택)
<!-- 리뷰어에게 전달할 추가 정보가 있다면 작성해주세요 -->
